### PR TITLE
Updated pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.11.13
     hooks:
       - id: ruff-format
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.1
+    rev: v5.0.2
     hooks:
       - id: reuse


### PR DESCRIPTION
Updated pre-commit hooks to their latest version:
* [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks): v4.5.0 -> v5.0.0
* [ruff](https://github.com/astral-sh/ruff-pre-commit): v0.3.4 -> v0.11.13
* [reuse](https://github.com/fsfe/reuse-tool): v3.0.1 -> v5.0.2

Resolves #17 