### PR TITLE
Fixed `Build CI` workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.11.13
     hooks:
       - id: ruff-format
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.1
+    rev: v5.0.2
     hooks:
       - id: reuse

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,7 @@ napoleon_numpy_docstring = False
 import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,7 @@ extend-select = [
   "PLC2401",  # non-ascii-name
   "PLC2801",  # unnecessary-dunder-call
   "PLC3002",  # unnecessary-direct-lambda-call
-  "E999",  # syntax-error
+# "E999",  # syntax-error
   "PLE0101",  # return-in-init
   "F706",  # return-outside-function
   "F704",  # yield-outside-function


### PR DESCRIPTION
Fixed `Build CI` workflow by updating `pre-commit` hooks and removing deprecated `ruff` rule `E999` and call to deprecated method `.get_html_theme_path()`.

Resolves #17 