### PR TITLE
Fixed `__version__` constant

### DIFF
--- a/button_handler.py
+++ b/button_handler.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.0.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/EGJ-Moorington/CircuitPython_Button_Handler.git"
 
 _TICKS_PERIOD = 1 << 29


### PR DESCRIPTION
Changed the `__version__` constant to `0.0.0+auto.0`, since build tools automatically change the constant based on the Git tag.

Resolves #25 