### PR TITLE
Updated `.readthedocs.yaml` with Sphinx configuration key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,10 @@ build:
   tools:
     python: "3"
 
+sphinx:
+  # Path to the Sphinx configuration file
+  configuration: docs/conf.py
+
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Added a Sphinx configuration key to `.readthedocs.yaml` so that the documentation can be built by Read the Docs again.

Resolves #26 