### PR TITLE
Updated `SPDX` licencing tags for release `3.0.1`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2025 EGJ Moorington
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/README.rst.license
+++ b/README.rst.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
-SPDX-FileCopyrightText: Copyright (c) 2024 EGJ Moorington
+SPDX-FileCopyrightText: Copyright (c) 2024, 2025 EGJ Moorington
 SPDX-License-Identifier: MIT

--- a/button_handler.py
+++ b/button_handler.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
-# SPDX-FileCopyrightText: Copyright (c) 2024 EGJ Moorington
+# SPDX-FileCopyrightText: Copyright (c) 2024, 2025 EGJ Moorington
 #
 # SPDX-License-Identifier: MIT
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# Copyright (c) 2025 EGJ Moorington
 #
 # SPDX-License-Identifier: MIT
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2025 EGJ Moorington
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Updated the `SPDX` licencing tags for release `3.0.1`.

Closes #33 