### PR TITLE
Fix/improve the example in the project's README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,10 @@ Or the following command to update an existing version:
 Usage Example
 =============
 
-This simple script showcases the usage of this library using a single button.
+This simple script showcases the usage of this library using a single
+button connected to pin D9, with custom ``multi_press_interval`` and
+``max_multi_press`` settings.  See the ``examples`` directory for
+more complex examples.
 
 +---------------+
 | Button wiring |
@@ -106,11 +109,15 @@ This simple script showcases the usage of this library using a single button.
     import board
     from keypad import Keys
 
-    from button_handler import ButtonHandler
+    from button_handler import ButtonHandler, ButtonInitConfig, ButtonInput
 
 
     def double_press():
         print("Double press detected!")
+
+
+    def triple_press():
+        print("Triple press detected!")
 
 
     def short_press():
@@ -125,16 +132,18 @@ This simple script showcases the usage of this library using a single button.
         print("The button began being held down!")
 
 
-    actions = {
-        "DOUBLE_PRESS": double_press,
-        "SHORT_PRESS": short_press,
-        "LONG_PRESS": long_press,
-        "HOLD": hold,
+    callback_inputs = {
+        ButtonInput(ButtonInput.DOUBLE_PRESS, 0, double_press),
+        ButtonInput(3, 0, triple_press),
+        ButtonInput(ButtonInput.SHORT_PRESS, 0, short_press),
+        ButtonInput(ButtonInput.LONG_PRESS, 0, long_press),
+        ButtonInput(ButtonInput.HOLD, 0, hold),
     }
 
-    scanner = Keys([board.D9], value_when_pressed=False)
-    button_handler = ButtonHandler(scanner.events, actions)
 
+    config = ButtonInitConfig(multi_press_interval=500, max_multi_press=3)
+    scanner = Keys((board.D9,), value_when_pressed=False, pull=True)
+    button_handler = ButtonHandler(scanner.events, callback_inputs, 1, {0: config})
 
     while True:
         button_handler.update()

--- a/README.rst
+++ b/README.rst
@@ -89,10 +89,11 @@ Or the following command to update an existing version:
 Usage Example
 =============
 
-This simple script showcases the usage of this library using a single
-button connected to pin D9, with custom ``multi_press_interval`` and
-``max_multi_press`` settings.  See the ``examples`` directory for
-more complex examples.
+This simple script showcases the usage of this library using a single button.
+
+See the ``examples`` directory for more complex examples, including
+triple presses, configuring button press delays, and supporting
+multiple buttons.
 
 +---------------+
 | Button wiring |
@@ -116,10 +117,6 @@ more complex examples.
         print("Double press detected!")
 
 
-    def triple_press():
-        print("Triple press detected!")
-
-
     def short_press():
         print("Short press detected!")
 
@@ -132,22 +129,21 @@ more complex examples.
         print("The button began being held down!")
 
 
-    callback_inputs = {
-        ButtonInput(ButtonInput.DOUBLE_PRESS, 0, double_press),
-        ButtonInput(3, 0, triple_press),
-        ButtonInput(ButtonInput.SHORT_PRESS, 0, short_press),
-        ButtonInput(ButtonInput.LONG_PRESS, 0, long_press),
-        ButtonInput(ButtonInput.HOLD, 0, hold),
+    actions = {
+        ButtonInput(ButtonInput.DOUBLE_PRESS, callback=double_press),
+        ButtonInput(ButtonInput.SHORT_PRESS, callback=short_press),
+        ButtonInput(ButtonInput.LONG_PRESS, callback=long_press),
+        ButtonInput(ButtonInput.HOLD, callback=hold),
     }
 
+    scanner = Keys([board.D9], value_when_pressed=False)
+    button_handler = ButtonHandler(scanner.events, actions)
 
-    config = ButtonInitConfig(multi_press_interval=500, max_multi_press=3)
-    scanner = Keys((board.D9,), value_when_pressed=False, pull=True)
-    button_handler = ButtonHandler(scanner.events, callback_inputs, 1, {0: config})
 
     while True:
         button_handler.update()
         time.sleep(0.0025)
+
 
 Documentation
 =============

--- a/examples/button_handler_fancier.py
+++ b/examples/button_handler_fancier.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2024 EGJ Moorington
+# SPDX-FileCopyrightText: Copyright (c) 2024 George Hartzell
+#
+# SPDX-License-Identifier: Unlicense
+
+#
+# Demonstrates:
+# - handling a triple press
+# - setting configurations for buttons (e.g. multi_press_interval)
+#
+import time
+
+import board
+from button_handler import ButtonHandler, ButtonInitConfig, ButtonInput
+from keypad import Keys
+
+
+def double_press():
+    print("Double press detected!")
+
+
+def triple_press():
+    print("Triple press detected!")
+
+
+def short_press():
+    print("Short press detected!")
+
+
+def long_press():
+    print("Long press detected!")
+
+
+def hold():
+    print("The button began being held down!")
+
+
+callback_inputs = {
+    ButtonInput(ButtonInput.DOUBLE_PRESS, 0, double_press),
+    ButtonInput(3, 0, triple_press),
+    ButtonInput(ButtonInput.SHORT_PRESS, 0, short_press),
+    ButtonInput(ButtonInput.LONG_PRESS, 0, long_press),
+    ButtonInput(ButtonInput.HOLD, 0, hold),
+}
+
+
+config = ButtonInitConfig(multi_press_interval=500, max_multi_press=3)
+scanner = Keys((board.D9,), value_when_pressed=False, pull=True)
+button_handler = ButtonHandler(scanner.events, callback_inputs, 1, {0: config})
+
+while True:
+    button_handler.update()
+    time.sleep(0.0025)

--- a/examples/button_handler_fancier.py
+++ b/examples/button_handler_fancier.py
@@ -12,8 +12,9 @@
 import time
 
 import board
-from button_handler import ButtonHandler, ButtonInitConfig, ButtonInput
 from keypad import Keys
+
+from button_handler import ButtonHandler, ButtonInitConfig, ButtonInput
 
 
 def double_press():


### PR DESCRIPTION
The example in the README didn't work (out of date?).

This:

- fixes the configuration of the ButtonHandler, using a set of ButtonInput objects for the callbacks; and
- makes the example slightly more complex/useful by demonstrating how to use the ButtonInitConfig objects and how to configure a callback for a triple press.